### PR TITLE
Add list order functionality

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListOrderCommand.java
@@ -1,0 +1,47 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.order.OrderStatusContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all orders whose status contains any of the argument keywords.
+ */
+public class ListOrderCommand extends Command {
+    public static final String COMMAND_WORD = "listorder";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all orders based on parameter listed "
+            + "and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD\n"
+            + "where KEYWORD is one of 'all', 'in_progress', 'delivered', 'cancelled'\n"
+            + "Example: " + COMMAND_WORD + " all";
+
+    private final OrderStatusContainsKeywordsPredicate predicate;
+
+    public ListOrderCommand(OrderStatusContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        if (predicate.getKeywords().get(0).equalsIgnoreCase("all")) {
+            model.updateFilteredOrderList(Model.PREDICATE_SHOW_ALL_ORDERS);
+        } else {
+            model.updateFilteredOrderList(predicate);
+        }
+        return new CommandResult(
+                String.format(Messages.MESSAGE_ORDERS_LISTED_OVERVIEW, model.getFilteredOrderList().size()), false,
+                false, false, false, true);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ListOrderCommand // instanceof handles nulls
+                && predicate.equals(((ListOrderCommand) other).predicate)); // state check
+    }
+}
+

--- a/src/main/java/seedu/address/logic/commands/ListOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListOrderCommand.java
@@ -15,7 +15,8 @@ public class ListOrderCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all orders based on parameter listed "
             + "and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD\n"
-            + "where KEYWORD is one of 'all', 'in_progress', 'delivered', 'cancelled'\n"
+            + "where KEYWORD is one of 'all', 'in_progress' or 'in progress', 'delivered', 'cancelled' "
+            + "(not case-sensitive)\n"
             + "Example: " + COMMAND_WORD + " all";
 
     private final OrderStatusContainsKeywordsPredicate predicate;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -26,6 +26,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListDishCommand;
 import seedu.address.logic.commands.ListDriverCommand;
+import seedu.address.logic.commands.ListOrderCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -99,6 +100,9 @@ public class AddressBookParser {
 
         case FindOrderCommand.COMMAND_WORD:
             return new FindOrderCommandParser().parse(arguments);
+
+        case ListOrderCommand.COMMAND_WORD:
+            return new ListOrderCommandParser().parse(arguments);
 
         case AddDriverCommand.COMMAND_WORD:
             return new AddDriverCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/ListDriverCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListDriverCommandParser.java
@@ -9,7 +9,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.driver.StatusContainsKeywordsPredicate;
 
 /**
- * Parses input arguments and creates a new ListDriverCommandParser object
+ * Parses input arguments and creates a new ListDriverCommand object
  */
 public class ListDriverCommandParser implements Parser<ListDriverCommand> {
 

--- a/src/main/java/seedu/address/logic/parser/ListOrderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListOrderCommandParser.java
@@ -1,0 +1,66 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+import seedu.address.logic.commands.ListOrderCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.order.OrderStatus;
+import seedu.address.model.order.OrderStatusContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new ListOrderCommand object
+ */
+public class ListOrderCommandParser implements Parser<ListOrderCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ListOrderCommand
+     * and returns a ListOrderCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListOrderCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListOrderCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        if (nameKeywords.length > 1) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListOrderCommand.MESSAGE_USAGE));
+        }
+
+        if (!orderStatusHasKeyword(nameKeywords[0])) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListOrderCommand.MESSAGE_USAGE));
+        }
+
+        return new ListOrderCommand(new OrderStatusContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+    /**
+     * Checks the given {@code String} argument and
+     * returns a boolean representing if enum OrderStatus contains argument or
+     * argument is equal to "all" (not case-sensitive)
+     */
+    private boolean orderStatusHasKeyword (String keyword) {
+        if (keyword.toUpperCase().equals("ALL")) {
+            return true;
+        }
+        boolean hasKeyword = false;
+        for (OrderStatus status : OrderStatus.values()) {
+            if (status.name().equals(keyword.toUpperCase())) {
+                hasKeyword = true;
+                break;
+            }
+        }
+
+        return hasKeyword;
+    }
+
+}
+

--- a/src/main/java/seedu/address/logic/parser/ListOrderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListOrderCommandParser.java
@@ -26,6 +26,10 @@ public class ListOrderCommandParser implements Parser<ListOrderCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListOrderCommand.MESSAGE_USAGE));
         }
 
+        if (trimmedArgs.equals("in progress")) {
+            trimmedArgs = "in_progress";
+        }
+
         String[] nameKeywords = trimmedArgs.split("\\s+");
 
         if (nameKeywords.length > 1) {

--- a/src/main/java/seedu/address/logic/parser/ListOrderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListOrderCommandParser.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
-import java.util.Locale;
 
 import seedu.address.logic.commands.ListOrderCommand;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/model/order/OrderStatusContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/order/OrderStatusContainsKeywordsPredicate.java
@@ -1,0 +1,33 @@
+package seedu.address.model.order;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+public class OrderStatusContainsKeywordsPredicate implements Predicate<Order> {
+    private final List<String> keywords;
+
+    public OrderStatusContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    public List<String> getKeywords() {
+        return keywords;
+    }
+
+    @Override
+    public boolean test(Order order) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(order.getStatus().name(), keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof OrderStatusContainsKeywordsPredicate
+                // instanceof handles nulls
+                && keywords.equals(((OrderStatusContainsKeywordsPredicate) other).keywords)); // state check
+    }
+}
+


### PR DESCRIPTION
Usage: `listorder KEYWORD`, where `KEYWORD` is one of `ALL, IN_PROGRESS, DELIVERED, CANCELLED` (not case-sensitive)

Additional checks: 
* Only allows 1 argument to be passed after listorder
* Checks if argument passed is either `ALL` or one of the OrderStatus